### PR TITLE
V1.1.12 tmc

### DIFF
--- a/macros/normalize_timestamp_to_utc.sql
+++ b/macros/normalize_timestamp_to_utc.sql
@@ -3,9 +3,9 @@
     CASE WHEN {{ time_stamp }} IS NOT NULL AND TRIM(CAST({{ time_stamp }} AS STRING)) != ''
 
     {% if convert_from_timezone != 'UTC' %}
-            THEN FORMAT_TIMESTAMP('%G-%m-%d %H:%M:%S', TIMESTAMP(CAST({{ time_stamp }} AS STRING), '{{ convert_from_timezone }}'), '{{ convert_to_timezone }}' )
+            THEN FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', TIMESTAMP(CAST({{ time_stamp }} AS STRING), '{{ convert_from_timezone }}'), '{{ convert_to_timezone }}' )
     {% else %}
-            THEN CAST(FORMAT_TIMESTAMP('%G-%m-%d %H:%M:%S', TIMESTAMP( {{ time_stamp }}), '{{ convert_to_timezone }}' )  AS TIMESTAMP)
+            THEN CAST(FORMAT_TIMESTAMP('%Y-%m-%d %H:%M:%S', TIMESTAMP( {{ time_stamp }}), '{{ convert_to_timezone }}' )  AS TIMESTAMP)
     {% endif %}
             ELSE NULL
         END

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -29,7 +29,7 @@ WITH
             STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
             STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
             STRING_AGG(source_schema) AS source_schema,
-            STRING_AGG(source_table) AS source_table
+            STRING_AGG(source_table) AS source_table, 
             -- additional columns
             {{ ngpvan__user__additional_fields("base_ngpvan__activistcodes") }}
             {{ ngpvan__metadata__select_fields(from_cte='base') }},

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -50,10 +50,10 @@ WITH
             republican_points,
             independent_points,
             committee_id,
-            action_type_id,
+            MAX(action_type_id) AS action_type_id,
             campaign_id,
-            is_active,
-            is_archived,
+            LOGICAL_AND(is_active) AS is_active,
+            LOGICAL_AND(is_archived) AS is_archived,
             segment_by,
             segmented_activist_code_id,
             vendor,
@@ -67,4 +67,3 @@ WITH
     )
 
 SELECT * FROM dedupe
-QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__activist_code_id ORDER BY action_type_id, is_active, is_archived) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -39,4 +39,4 @@ WITH
 SELECT
     DISTINCT *
 FROM renamed
-
+-- likely we just want to dedupe by source schema, it looks like we're getting dupes from Bonterra and AV

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -16,8 +16,8 @@ WITH
             reppoints AS republican_points,
             indpoints AS independent_points,
             committeeid AS committee_id,
-            actiontypeid AS action_type_id,
-            campaignid AS campaign_id,
+            CASE WHEN actiontypeid = 0 THEN NULL ELSE actiontypeid END AS action_type_id,
+            CASE WHEN campaignid = 0 THEN NULL ELSE campaignid END AS campaign_id,
             CASE WHEN active = 1
                     THEN TRUE
                     ELSE FALSE
@@ -39,4 +39,25 @@ WITH
 SELECT
     DISTINCT *
 FROM renamed
--- likely we just want to dedupe by source schema, it looks like we're getting dupes from Bonterra and AV
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY
+        vendor_unique_stg_ngpvan__activist_code_id,
+        activist_code_id,
+        van_state_id,
+        activist_code_type,
+        activist_code_name,
+        activist_code_description,
+        report_question,
+        democrat_points,
+        republican_points,
+        independent_points,
+        committee_id,
+        action_type_id,
+        campaign_id,
+        is_active,
+        is_archived,
+        segment_by,
+        segmented_activist_code_id,
+        vendor,
+        segment_by_key
+) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -26,7 +26,10 @@ WITH
                     THEN TRUE
                     ELSE FALSE
                 END AS is_archived,
-
+            STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
+            STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
+            STRING_AGG(source_schema) AS source_schema,
+            STRING_AGG(source_table) AS source_table
             -- additional columns
             {{ ngpvan__user__additional_fields("base_ngpvan__activistcodes") }}
             {{ ngpvan__metadata__select_fields(from_cte='base') }},
@@ -34,30 +37,9 @@ WITH
             {{ ngpvan__stg__additional_fields() }}
 
         FROM base
+        GROUP BY ALL
     )
 
 SELECT
     DISTINCT *
 FROM renamed
-QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY
-        vendor_unique_stg_ngpvan__activist_code_id,
-        activist_code_id,
-        van_state_id,
-        activist_code_type,
-        activist_code_name,
-        activist_code_description,
-        report_question,
-        democrat_points,
-        republican_points,
-        independent_points,
-        committee_id,
-        action_type_id,
-        campaign_id,
-        is_active,
-        is_archived,
-        segment_by,
-        segmented_activist_code_id,
-        vendor,
-        segment_by_key
-) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -67,3 +67,4 @@ WITH
     )
 
 SELECT * FROM dedupe
+QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__activist_code_id ORDER BY action_type_id, is_active, is_archived) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -26,10 +26,6 @@ WITH
                     THEN TRUE
                     ELSE FALSE
                 END AS is_archived,
-            STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
-            STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
-            STRING_AGG(source_schema) AS source_schema,
-            STRING_AGG(source_table) AS source_table, 
             -- additional columns
             {{ ngpvan__user__additional_fields("base_ngpvan__activistcodes") }}
             {{ ngpvan__metadata__select_fields(from_cte='base') }},
@@ -38,8 +34,35 @@ WITH
 
         FROM base
         GROUP BY ALL
+    ),
+
+    dedupe AS (
+        SELECT
+            DISTINCT 
+            activist_code_id,
+            van_state_id,
+            activist_code_type,
+            activist_code_name,
+            activist_code_description,
+            report_question,
+            democrat_points,
+            republican_points,
+            independent_points,
+            committee_id,
+            action_type_id,
+            campaign_id,
+            is_active,
+            is_archived,
+            segment_by,
+            segmented_activist_code_id,
+            vendor,
+            segment_by_key,
+            STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
+            STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
+            STRING_AGG(source_schema) AS source_schema,
+            STRING_AGG(source_table) AS source_table
+        FROM renamed
+        GROUP BY ALL
     )
 
-SELECT
-    DISTINCT *
-FROM renamed
+SELECT * FROM dedupe

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -43,7 +43,7 @@ WITH
             activist_code_id,
             van_state_id,
             activist_code_type,
-            activist_code_name,
+            TRIM(activist_code_name) AS activist_code_name,
             activist_code_description,
             report_question,
             democrat_points,

--- a/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__activist_codes.sql
@@ -39,6 +39,7 @@ WITH
     dedupe AS (
         SELECT
             DISTINCT 
+            vendor_unique_stg_ngpvan__activist_code_id,
             activist_code_id,
             van_state_id,
             activist_code_type,

--- a/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
@@ -89,4 +89,4 @@ WITH
     )
 
 SELECT DISTINCT * FROM renamed
-QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__contacts_contacts_id ORDER BY utc_modified_at DESC NULLS LAST) = 1
+-- QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__contacts_contacts_id ORDER BY utc_modified_at DESC NULLS LAST) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
@@ -89,4 +89,3 @@ WITH
     )
 
 SELECT DISTINCT * FROM renamed
--- QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__contacts_contacts_id ORDER BY utc_modified_at DESC NULLS LAST) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__contacts_contacts.sql
@@ -88,4 +88,5 @@ WITH
 
     )
 
-SELECT * FROM renamed
+SELECT DISTINCT * FROM renamed
+QUALIFY ROW_NUMBER() OVER (PARTITION BY vendor_unique_stg_ngpvan__contacts_contacts_id ORDER BY utc_modified_at DESC NULLS LAST) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__contacts_survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__contacts_survey_responses.sql
@@ -52,4 +52,3 @@ WITH
     )
 
 SELECT * FROM renamed
-

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
@@ -31,6 +31,9 @@ WITH
     )
 
 SELECT * FROM renamed
+-- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
+-- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
+-- source_schema, source_table)
 QUALIFY ROW_NUMBER() OVER (PARTITION BY 
     survey_question_id, 
     van_state_id, 

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
@@ -1,32 +1,49 @@
-
 WITH
     base AS (
         SELECT * FROM {{ ref('base_ngpvan__surveyquestions') }}
+    ), 
+
+    renamed as (
+        SELECT
+            surveyquestionid AS survey_question_id,
+            stateid AS van_state_id,
+            cycle AS election_cycle,
+            surveyquestiontype AS survey_question_type,
+            surveyquestionname AS survey_question_name,
+            surveyquestiontext AS survey_question_text,
+            mastersurveyquestionid AS master_survey_question_id,
+            createdcommitteeid AS committee_id,
+            CASE WHEN active = 1
+                    THEN TRUE
+                    ELSE FALSE
+                END AS is_active,
+            CASE WHEN active = 5
+                    THEN TRUE
+                    ELSE FALSE
+                END AS is_archived,
+
+            -- additional columns
+            {{ ngpvan__user__additional_fields("base_ngpvan__surveyquestions") }}
+            {{ ngpvan__metadata__select_fields(from_cte='base') }},
+            CONCAT(segment_by, '-', surveyquestionid) AS segmented_survey_question_id
+            {{ ngpvan__stg__additional_fields() }}
+        FROM base
     )
 
-SELECT
-    surveyquestionid AS survey_question_id,
-    stateid AS van_state_id,
-    cycle AS election_cycle,
-    surveyquestiontype AS survey_question_type,
-    surveyquestionname AS survey_question_name,
-    surveyquestiontext AS survey_question_text,
-    mastersurveyquestionid AS master_survey_question_id,
-    createdcommitteeid AS committee_id,
-    CASE WHEN active = 1
-            THEN TRUE
-            ELSE FALSE
-        END AS is_active,
-    CASE WHEN active = 5
-            THEN TRUE
-            ELSE FALSE
-        END AS is_archived,
-
-    -- additional columns
-    {{ ngpvan__user__additional_fields("base_ngpvan__surveyquestions") }}
-    {{ ngpvan__metadata__select_fields(from_cte='base') }},
-    CONCAT(segment_by, '-', surveyquestionid) AS segmented_survey_question_id
-    {{ ngpvan__stg__additional_fields() }}
-
-FROM base
-
+SELECT * FROM renamed
+QUALIFY ROW_NUMBER() OVER (PARTITION BY 
+    survey_question_id, 
+    van_state_id, 
+    election_cycle, 
+    survey_question_type, 
+    urvey_question_name, 
+    survey_question_text, 
+    master_survey_question_id, 
+    committee_id, 
+    is_active, 
+    is_archived,
+    segment_by,
+    segmented_survey_question_id,
+    vendor,
+    segment_by_key,
+    vendor_unique_stg_ngpvan__survey_question_id) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
@@ -39,7 +39,7 @@ QUALIFY ROW_NUMBER() OVER (PARTITION BY
     van_state_id, 
     election_cycle, 
     survey_question_type, 
-    urvey_question_name, 
+    survey_question_name, 
     survey_question_text, 
     master_survey_question_id, 
     committee_id, 

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_questions.sql
@@ -31,22 +31,3 @@ WITH
     )
 
 SELECT * FROM renamed
--- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
--- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
--- source_schema, source_table)
-QUALIFY ROW_NUMBER() OVER (PARTITION BY 
-    survey_question_id, 
-    van_state_id, 
-    election_cycle, 
-    survey_question_type, 
-    survey_question_name, 
-    survey_question_text, 
-    master_survey_question_id, 
-    committee_id, 
-    is_active, 
-    is_archived,
-    segment_by,
-    segmented_survey_question_id,
-    vendor,
-    segment_by_key,
-    vendor_unique_stg_ngpvan__survey_question_id) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
@@ -19,7 +19,7 @@ WITH
             base.dempoints AS democrat_points,
             base.reppoints AS republican_points,
             base.indpoints AS independent_points,
-            base.mastersurveyresponseid AS master_survey_response_id,
+            CASE WHEN base.mastersurveyresponseid = 0 THEN NULL ELSE base.mastersurveyresponseid END AS master_survey_response_id,
             surveyquestions.committeeid AS committee_id,
 
             -- additional columns

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
@@ -36,20 +36,20 @@ SELECT DISTINCT * FROM responses
 -- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
 -- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
 -- source_schema, source_table)
--- QUALIFY ROW_NUMBER() OVER (
---     PARTITION BY 
---         survey_question_id,
---         survey_response_id,
---         survey_response,
---         democrat_points,
---         republican_points,
---         independent_points,
---         master_survey_response_id,
---         committee_id,
---         segment_by,
---         segmented_survey_response_id,
---         segmented_survey_question_id,
---         vendor,
---         segment_by_key,
---         vendor_unique_stg_ngpvan__survey_response_id
--- ) = 1
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY 
+        survey_question_id,
+        survey_response_id,
+        survey_response,
+        democrat_points,
+        republican_points,
+        independent_points,
+        master_survey_response_id,
+        committee_id,
+        segment_by,
+        segmented_survey_response_id,
+        segmented_survey_question_id,
+        vendor,
+        segment_by_key,
+        vendor_unique_stg_ngpvan__survey_response_id
+) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
@@ -33,3 +33,23 @@ WITH
     )
 
 SELECT DISTINCT * FROM responses
+-- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
+-- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
+-- source_schema, source_table)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY 
+        survey_question_id,
+        survey_response_id,
+        survey_response,
+        democrat_points,
+        republican_points,
+        independent_points,
+        master_survey_response_id,
+        committee_id,
+        segment_by,
+        segmented_survey_response_id,
+        segmented_survey_question_id,
+        vendor,
+        segment_by_key,
+        vendor_unique_stg_ngpvan__survey_response_id
+) = 1

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
@@ -30,26 +30,31 @@ WITH
             {{ ngpvan__stg__additional_fields() }}
         FROM base
         LEFT JOIN surveyquestions USING (surveyquestionid)
+    ),
+
+    dedupe AS (
+        SELECT 
+            DISTINCT
+            survey_question_id,
+            survey_response_id,
+            survey_response,
+            democrat_points,
+            republican_points,
+            independent_points,
+            master_survey_response_id,
+            committee_id,
+            STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
+            STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
+            STRING_AGG(source_schema) AS source_schema,
+            STRING_AGG(source_table) AS source_table,
+            segment_by,
+            segmented_survey_response_id,
+            segmented_survey_question_id,
+            vendor,
+            segment_by_key,
+            vendor_unique_stg_ngpvan__survey_response_id
+        FROM responses
+        GROUP BY ALL
     )
 
-SELECT DISTINCT * FROM responses
--- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
--- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
--- source_schema, source_table)
-QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY 
-        survey_question_id,
-        survey_response_id,
-        survey_response,
-        democrat_points,
-        republican_points,
-        independent_points,
-        master_survey_response_id,
-        committee_id,
-        segment_by,
-        segmented_survey_response_id,
-        segmented_survey_question_id,
-        vendor,
-        segment_by_key,
-        vendor_unique_stg_ngpvan__survey_response_id
-) = 1
+SELECT DISTINCT * FROM dedupe

--- a/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__survey_responses.sql
@@ -36,20 +36,20 @@ SELECT DISTINCT * FROM responses
 -- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
 -- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
 -- source_schema, source_table)
-QUALIFY ROW_NUMBER() OVER (
-    PARTITION BY 
-        survey_question_id,
-        survey_response_id,
-        survey_response,
-        democrat_points,
-        republican_points,
-        independent_points,
-        master_survey_response_id,
-        committee_id,
-        segment_by,
-        segmented_survey_response_id,
-        segmented_survey_question_id,
-        vendor,
-        segment_by_key,
-        vendor_unique_stg_ngpvan__survey_response_id
-) = 1
+-- QUALIFY ROW_NUMBER() OVER (
+--     PARTITION BY 
+--         survey_question_id,
+--         survey_response_id,
+--         survey_response,
+--         democrat_points,
+--         republican_points,
+--         independent_points,
+--         master_survey_response_id,
+--         committee_id,
+--         segment_by,
+--         segmented_survey_response_id,
+--         segmented_survey_question_id,
+--         vendor,
+--         segment_by_key,
+--         vendor_unique_stg_ngpvan__survey_response_id
+-- ) = 1

--- a/models/staging/ngpvan/stg_ngpvan__users.sql
+++ b/models/staging/ngpvan/stg_ngpvan__users.sql
@@ -11,7 +11,7 @@ WITH
             username AS username,
             INITCAP(firstname) AS first_name,
             INITCAP(lastname) AS last_name,
-            INITCAP(TRIM(canvassername)) AS public_username,
+            TRIM(INITCAP(canvassername)) AS public_username,
             address1 AS address_line_1,
             city AS city,
             state,

--- a/models/staging/ngpvan/stg_ngpvan__users.sql
+++ b/models/staging/ngpvan/stg_ngpvan__users.sql
@@ -9,8 +9,8 @@ WITH
 
             userid AS user_id,
             username AS username,
-            INITCAP(firstname) AS first_name,
-            INITCAP(lastname) AS last_name,
+            TRIM(INITCAP(firstname)) AS first_name,
+            TRIM(INITCAP(lastname)) AS last_name,
             TRIM(INITCAP(canvassername)) AS public_username,
             address1 AS address_line_1,
             city AS city,

--- a/models/staging/ngpvan/stg_ngpvan__users.sql
+++ b/models/staging/ngpvan/stg_ngpvan__users.sql
@@ -11,7 +11,7 @@ WITH
             username AS username,
             INITCAP(firstname) AS first_name,
             INITCAP(lastname) AS last_name,
-            INITCAP(canvassername) AS public_username,
+            INITCAP(TRIM(canvassername)) AS public_username,
             address1 AS address_line_1,
             city AS city,
             state,

--- a/models/staging/ngpvan/stg_ngpvan__users.sql
+++ b/models/staging/ngpvan/stg_ngpvan__users.sql
@@ -26,30 +26,35 @@ WITH
             {{ ngpvan__stg__additional_fields() }}
 
         FROM base
+    ),
+
+    dedupe AS (
+        SELECT
+            DISTINCT
+            user_id,
+            username,
+            first_name,
+            last_name,
+            public_username,
+            address_line_1,
+            city,
+            state,
+            zip_code,
+            email_address,
+            home_phone,
+            cell_phone,
+            STRING_AGG(_avvan_source_relation) AS _avvan_source_relation,
+            STRING_AGG(_dbt_source_relation) AS _dbt_source_relation,
+            STRING_AGG(source_schema) AS source_schema,
+            STRING_AGG(source_table) AS source_table,
+            segment_by,
+            vendor,
+            vendor_unique_stg_ngpvan__user_id
+        FROM renamed
+        GROUP BY ALL
     )
 
 SELECT
     *
-FROM renamed
--- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
--- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
--- source_schema, source_table)
-QUALIFY ROW_NUMBER() OVER (
-    PARTITION by
-        user_id,
-        username,
-        first_name,
-        last_name,
-        public_username,
-        address_line_1,
-        city,
-        state,
-        zip_code,
-        email_address,
-        home_phone,
-        cell_phone,
-        segment_by,
-        vendor,
-        vendor_unique_stg_ngpvan__user_id
-) = 1
+FROM dedupe
 

--- a/models/staging/ngpvan/stg_ngpvan__users.sql
+++ b/models/staging/ngpvan/stg_ngpvan__users.sql
@@ -31,4 +31,25 @@ WITH
 SELECT
     *
 FROM renamed
+-- We get some data from both Bonterra and AV, so this dedupes by partitioning on 
+-- everything except variables defining the source (i.e. _dbt_source_relation, _avvan_source_relation,
+-- source_schema, source_table)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION by
+        user_id,
+        username,
+        first_name,
+        last_name,
+        public_username,
+        address_line_1,
+        city,
+        state,
+        zip_code,
+        email_address,
+        home_phone,
+        cell_phone,
+        segment_by,
+        vendor,
+        vendor_unique_stg_ngpvan__user_id
+) = 1
 


### PR DESCRIPTION
- Activist Codes: dupes from Bonterra and AV are only different in 2 columns where Bonterra has 0 and AV has null, so it coverts 0s to nulls then does a qualify over all variables except source variables (_dbt_source_relation, source_schema, etc.)
- Contacts Contacts: Final distinct removes dupes under test conditions, at least for newer data.
- Survey Responses: dupes from Bonterra and AV so doing a qualify over all variables except source variables
- Users: dupes from Bonterra and AV so doing a qualify over all variables except source variables. Also one dupe was because of trailing whitespace in name, so trims name. 