### PR TITLE
remove one bad row

### DIFF
--- a/models/staging/ngpvan/_stg_ngpvan.yaml
+++ b/models/staging/ngpvan/_stg_ngpvan.yaml
@@ -246,6 +246,11 @@ models:
         description: '{{ doc("segment_by_key") }}'
       - name: vendor_unique_stg_ngpvan__committee_id
         description: '{{ doc("vendor_unique_id") }}'
+        tests:
+          - not_null
+          - unique:
+              config:
+                severity: error
   - name: stg_ngpvan__contact_types
     description: '{{ doc("bonterra_missing") }}'
     tests:

--- a/models/staging/ngpvan/core/stg_ngpvan__committees.sql
+++ b/models/staging/ngpvan/core/stg_ngpvan__committees.sql
@@ -33,4 +33,6 @@ WITH
 SELECT
     DISTINCT *
 FROM renamed
+-- hard-coding out one bad committee from AV while we work with them to remove from raw
+WHERE NOT (committee_id = 15701 AND committee_short_name IS NULL)
 


### PR DESCRIPTION
Hard-coded removal of a bad row in the committees table from AV that's introducing dupes while we work with AV to remove from raw