### PR TITLE
Adding more join keys to intermediate models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ development.env
 *.ipynb
 profiles.yml
 dbt_project_tmc_rs.yml
+dbt_internal_packages/

--- a/models/intermediate/ngpvan/int_ngpvan__01__activist_codes.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__activist_codes.sql
@@ -33,14 +33,17 @@ WITH
             committee_id,
             committee_name,
             committee_short_name,
-            committee_type
+            committee_type,
+            segment_by
         FROM {{ ref("stg_ngpvan__committees") }}
     ),
 
     campaigns AS (
         SELECT
             campaign_id,
-            campaign_name
+            campaign_name,
+            committee_id,
+            segment_by
         FROM {{ ref("stg_ngpvan__campaigns") }}
     ),
 
@@ -88,9 +91,17 @@ WITH
             {{ ngpvan__int__additional_fields() }}
 
         FROM contacts
-        LEFT JOIN codes USING (activist_code_id)
-        LEFT JOIN committees USING (committee_id)
-        LEFT JOIN campaigns USING (campaign_id)
+        LEFT JOIN codes 
+            ON contacts.activist_code_id = codes.activist_code_id 
+                AND contacts.committee_id = codes.activist_code_committee_id
+                AND contacts.segment_by = codes.segment_by
+        LEFT JOIN committees 
+            ON contacts.committee_id = committees.committee_id 
+                AND contacts.segment_by = committees.segment_by
+        LEFT JOIN campaigns 
+            ON contacts.campaign_id = campaigns.campaign_id 
+            AND contacts.committee_id = campaigns.committee_id 
+            AND contacts.segment_by = campaigns.segment_by
     )
 
 SELECT * FROM activist_codes

--- a/models/intermediate/ngpvan/int_ngpvan__01__admins.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__admins.sql
@@ -95,7 +95,9 @@ WITH
             {{- ngpvan__int__additional_fields() }}
 
         FROM all_users users
-        LEFT JOIN user_groups USING (user_id) 
+        LEFT JOIN user_groups 
+            ON users.user_id = user_groups.user_id 
+                AND users.segment_by = user_groups.segment_by
         GROUP BY           
             users.user_id,
             users.username,

--- a/models/intermediate/ngpvan/int_ngpvan__01__admins.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__admins.sql
@@ -29,7 +29,8 @@ WITH
         SELECT
             user_id,
             user_group_id,
-            user_group_name
+            user_group_name,
+            segment_by
         FROM {{ ref("stg_ngpvan__users_user_groups") }}
     ),
 

--- a/models/intermediate/ngpvan/int_ngpvan__01__contact_attempts.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__contact_attempts.sql
@@ -9,14 +9,17 @@ WITH
             committee_id,
             committee_name,
             committee_short_name,
-            committee_type
+            committee_type,
+            segment_by
         FROM {{ ref("stg_ngpvan__committees") }}
     ),
 
     campaigns AS (
         SELECT
             campaign_id,
-            campaign_name
+            campaign_name,
+            committee_id,
+            segment_by
         FROM {{ ref("stg_ngpvan__campaigns") }}
     ),
 
@@ -61,8 +64,13 @@ WITH
             {{ ngpvan__int__additional_fields() }}
 
         FROM contacts
-        LEFT JOIN committees USING (committee_id)
-        LEFT JOIN campaigns USING (campaign_id)
+        LEFT JOIN committees 
+            ON contacts.committee_id = committees.committee_id 
+                AND contacts.segment_by = committees.segment_by
+        LEFT JOIN campaigns 
+            ON contacts.campaign_id = campaigns.campaign_id 
+                AND contacts.committee_id = campaigns.committee_id
+                AND contacts.segment_by = campaigns.segment_by
     )
 
 SELECT * FROM contact_attempts

--- a/models/intermediate/ngpvan/int_ngpvan__01__survey_responses.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__survey_responses.sql
@@ -32,7 +32,8 @@ WITH
             master_survey_question_id,
             committee_id AS survey_question_committee_id,
             is_active,
-            is_archived
+            is_archived,
+            segment_by
         FROM {{ ref("stg_ngpvan__survey_questions") }}
     ),
 
@@ -41,14 +42,17 @@ WITH
             committee_id,
             committee_name,
             committee_short_name,
-            committee_type
+            committee_type,
+            segment_by
         FROM {{ ref("stg_ngpvan__committees") }}
     ),
 
     campaigns AS (
         SELECT
             campaign_id,
-            campaign_name
+            campaign_name,
+            committee_id,
+            segment_by
         FROM {{ ref("stg_ngpvan__campaigns") }}
     ),
 
@@ -100,13 +104,23 @@ WITH
             contacts.source_table,
             contacts.segment_by
             {{ ngpvan__int__additional_fields() }}
-
-
         FROM contacts
-        LEFT JOIN responses USING (survey_question_id, survey_response_id)
-        LEFT JOIN questions USING (survey_question_id)
-        LEFT JOIN committees ON (committees.committee_id = COALESCE(contacts.committee_id, questions.survey_question_committee_id, responses.survey_response_committee_id))
-        LEFT JOIN campaigns USING (campaign_id)
+        LEFT JOIN responses 
+            ON contacts.survey_question_id = responses.survey_question_id 
+                AND contacts.survey_response_id = responses.survey_response_id 
+                AND contacts.committee_id = responses.survey_response_committee_id
+                AND contacts.segment_by = responses.segment_by
+        LEFT JOIN questions 
+            ON contacts.survey_question_id = questions.survey_question_id 
+                AND contacts.committee_id = questions.survey_question_committee_id
+                AND contacts.segment_by = questions.segment_by
+        LEFT JOIN committees 
+            ON (committees.committee_id = COALESCE(contacts.committee_id, questions.survey_question_committee_id, responses.survey_response_committee_id))
+                AND committees.segment_by = contacts.segment_by
+        LEFT JOIN campaigns 
+            ON contacts.campaign_id = campaigns.campaign_id
+                AND contacts.committee_id = campaigns.committee_id
+                AND contacts.segment_by = campaigns.segment_by
     )
 
 SELECT * FROM survey_responses


### PR DESCRIPTION
- A member noticed duplicate records in `enh_van__survey_responses`, and after investigating I found that the joins in `int_ngpvan__01__survey_responses` were causing the duplicates.
- I added `committee_id` and `segment_by` to all of the left joins in `int_ngpvan__01__survey_responses`, and when I ran the model in my development environment there were no more duplicates.
- I also added to the joins in the other intermediate models in case they were having the same issue. I ran all of them in my development environment and they all succeeded!