### PR TITLE
Adjusting models/intermediate/ngpvan/int_ngpvan__01__contact_attempts.sql join

### DIFF
--- a/models/intermediate/ngpvan/int_ngpvan__01__contact_attempts.sql
+++ b/models/intermediate/ngpvan/int_ngpvan__01__contact_attempts.sql
@@ -68,9 +68,7 @@ WITH
             ON contacts.committee_id = committees.committee_id 
                 AND contacts.segment_by = committees.segment_by
         LEFT JOIN campaigns 
-            ON contacts.campaign_id = campaigns.campaign_id 
-                AND contacts.committee_id = campaigns.committee_id
-                AND contacts.segment_by = campaigns.segment_by
+            USING (campaign_id)
     )
 
 SELECT * FROM contact_attempts


### PR DESCRIPTION
HIA mentioned that a downstream table is not getting some campaign_names populated and the source of that is this table. Campaign_id appears to be globally unique based on a check in data marts.